### PR TITLE
se-10612 Add content processing from Registry

### DIFF
--- a/src/Logger.php
+++ b/src/Logger.php
@@ -142,6 +142,12 @@ class Logger
                 $record['context']['engine_id'] = $_SESSION['auth']['current_engine_id'];
             }
 
+            if (class_exists('Registry')) {
+                 foreach (\Registry::getLogContext() as $key => $value) {
+                    $record['context'][$key] ??= $value;
+                 }
+            }
+
             $record['extra'] = array_merge($record['extra'], $extra);
 
             return $record;


### PR DESCRIPTION
в ядре и других старых репо проблемно внедрить глобальные контейнеры, поэтому самый простой вариант - использовать Registry
пример использования - https://github.com/searchanise/searchanise/pull/1660/files